### PR TITLE
fix: add notifying

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,7 @@
 class PingPong
 {
 public:
-	static constexpr std::size_t MAX = 3;
+	static constexpr std::size_t MAX = 5;
 
 	void ping()
 	{
@@ -18,6 +18,7 @@ public:
         	cv_.notify_all();
         	cv_.wait(lock);
     	}
+        cv_.notify_all();
  	}
 
 	void pong()
@@ -30,6 +31,7 @@ public:
         	cv_.notify_all();
         	cv_.wait(lock);
     	}
+        cv_.notify_all();
 	}
 
 private:


### PR DESCRIPTION
Возникла проблема с локом тредов, если количество доступных понгов или пингов закончилось. Так как после завершения цикла тред не сообщает другому что стоит проверить ограничение и завершится. Был добавлен `cv_.notify_all();`, который заставит проверить условие.